### PR TITLE
cg-proc -w: Only uppercase if whole form upper, uppercase all baseforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Makefile
 /src/cmake_install.cmake
 /src/CTestTestfile.cmake
 /install_manifest.txt
+.ccls-cache/

--- a/src/ApertiumApplicator.cpp
+++ b/src/ApertiumApplicator.cpp
@@ -769,7 +769,7 @@ void ApertiumApplicator::printReading(Reading* reading, std::ostream& output) {
 
 			// similar to fst_processor.cc in lttoolbox:
 			bool firstupper = firstlower < wf.length() && (u_isupper(wf[firstlower]) != 0);
-			bool uppercase = wf == wfUPPER;
+			bool uppercase = wf.length() >= 2 && wf == wfUPPER;
 
 			if (uppercase) {
 				casing = ApertiumCasing::Upper;

--- a/src/ApertiumApplicator.cpp
+++ b/src/ApertiumApplicator.cpp
@@ -640,13 +640,9 @@ void ApertiumApplicator::testPR(std::ostream& output) {
 	}
 }
 
-void ApertiumApplicator::printReading(Reading* reading, std::ostream& output) {
-	if (reading->noprint) {
-		return;
-	}
-
+void ApertiumApplicator::printReading(Reading* reading, std::ostream& output, ApertiumCasing casing, int firstlower) {
 	if (reading->next) {
-		printReading(reading->next, output);
+		printReading(reading->next, output, casing, firstlower);
 		u_fputc('+', output);
 	}
 
@@ -654,33 +650,15 @@ void ApertiumApplicator::printReading(Reading* reading, std::ostream& output) {
 		// Lop off the initial and final '"' characters
 		UnicodeString bf(single_tags[reading->baseform]->tag.c_str() + 1, static_cast<int32_t>(single_tags[reading->baseform]->tag.size() - 2));
 
-		if (wordform_case && !reading->next) {
-			// Use surface/wordform case, eg. if lt-proc
-			// was called with "-w" option (which puts
-			// dictionary case on lemma/basefrom)
-			// Lop off the initial and final '"<>"' characters
-			// ToDo: A copy does not need to be made here - use pointer offsets
-			UnicodeString wf(reading->parent->wordform->tag.c_str() + 2, static_cast<int32_t>(reading->parent->wordform->tag.size() - 4));
-
-			int first = 0; // first occurrence of a lowercase character in baseform
-			for (; first < bf.length(); ++first) {
-				if (u_islower(bf[first]) != 0) {
-					break;
-				}
-			}
-
-			// this corresponds to fst_processor.cc in lttoolbox:
-			bool firstupper = first < wf.length() && (u_isupper(wf[first]) != 0);
-			bool uppercase = firstupper && u_isupper(wf[wf.length() - 1]);
-
-			if (uppercase) {
+		if (wordform_case) {
+			if (casing == ApertiumCasing::Upper) {
 				bf.toUpper(); // Perform a Unicode case folding to upper case -- Tino Didriksen
 			}
-			else if (firstupper && first < bf.length()) {
+			else if (casing == ApertiumCasing::Title && !reading->next) {
 				// static_cast<UChar>(u_toupper(bf[first])) gives strange output
-				UnicodeString range(bf, first, 1);
+				UnicodeString range(bf, firstlower, 1);
 				range.toUpper();
-				bf.setCharAt(first, range[0]);
+				bf.setCharAt(firstlower, range[0]);
 			}
 		} // if (wordform_case)
 
@@ -753,6 +731,56 @@ void ApertiumApplicator::printReading(Reading* reading, std::ostream& output) {
 		}
 	}
 }
+
+void ApertiumApplicator::printReading(Reading* reading, std::ostream& output) {
+	if (reading->noprint) {
+		return;
+	}
+
+	int firstlower = 0;
+	ApertiumCasing casing = ApertiumCasing::Lower;
+
+	if (wordform_case) {
+		Reading* last = reading;
+		while (last->next && last->next->baseform) {
+			last = last->next;
+		}
+		if (last->baseform) {
+			// Lop off the initial and final '"' characters
+			// ToDo: A copy does not need to be made here - use pointer offsets
+			UnicodeString bf(single_tags[last->baseform]->tag.c_str() + 1, static_cast<int32_t>(single_tags[last->baseform]->tag.size() - 2));
+
+			// Use surface/wordform case, eg. if lt-proc
+			// was called with "-w" option (which puts
+			// dictionary case on lemma/basefrom)
+			// Lop off the initial and final '"<>"' characters
+			// ToDo: A copy does not need to be made here - use pointer offsets
+			UnicodeString wf(reading->parent->wordform->tag.c_str() + 2, static_cast<int32_t>(reading->parent->wordform->tag.size() - 4));
+
+			UnicodeString wfUPPER(reading->parent->wordform->tag.c_str() + 2, static_cast<int32_t>(reading->parent->wordform->tag.size() - 4));
+			wfUPPER.toUpper();
+
+			for (; firstlower < bf.length(); ++firstlower) {
+				if (u_islower(bf[firstlower]) != 0) {
+					break;
+				}
+			}
+
+			// similar to fst_processor.cc in lttoolbox:
+			bool firstupper = firstlower < wf.length() && (u_isupper(wf[firstlower]) != 0);
+			bool uppercase = wf == wfUPPER;
+
+			if (uppercase) {
+				casing = ApertiumCasing::Upper;
+			}
+			else if (firstupper && firstlower < bf.length()) {
+				casing = ApertiumCasing::Title;
+			}
+		}
+	} // if (wordform_case)
+	printReading(reading, output, casing, firstlower);
+}
+
 
 void ApertiumApplicator::printSingleWindow(SingleWindow* window, std::ostream& output) {
 	// Window text comes at the left

--- a/src/ApertiumApplicator.hpp
+++ b/src/ApertiumApplicator.hpp
@@ -26,6 +26,9 @@
 #include "GrammarApplicator.hpp"
 
 namespace CG3 {
+
+enum ApertiumCasing { Lower, Title, Upper };
+
 class ApertiumApplicator : public virtual GrammarApplicator {
 public:
 	ApertiumApplicator(std::ostream& ux_err);
@@ -51,6 +54,7 @@ protected:
 	void mergeMappings(Cohort& cohort);
 
 private:
+	void printReading(Reading* reading, std::ostream& output, ApertiumCasing casing, int firstlower);
 	void processReading(Reading* cReading, const UChar* reading_string);
 	void processReading(Reading* cReading, const UString& reading_string);
 };


### PR DESCRIPTION
The wordform «Håndball-VM» used to give

```
 /HÅNDBALL<n><m><sg><ind><cmp><guio>+vm<n><nt><sg><ind>$
```

now titlecases first subreading instead of uppercasing:
```
 /Håndball<n><m><sg><ind><cmp><guio>+vm<n><nt><sg><ind>$
```

The wordform «HÅNDBALL-VM» used to give
```
 /HÅNDBALL<n><m><sg><ind><cmp><guio>+vm<n><nt><sg><ind>$
```

now uppercases second subreading too:
```
 /HÅNDBALL<n><m><sg><ind><cmp><guio>+VM<n><nt><sg><ind>$
```

Unfortunately doesn't do anything for https://github.com/TinoDidriksen/cg3/issues/24

(Can we do the wf==wfUPPER bit without creating new UnicodeString's?)
