### PR TITLE
Swig wrapper for cg-proc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,17 @@ Makefile
 /src/CTestTestfile.cmake
 /install_manifest.txt
 .ccls-cache/
+*so*
+
+__pycache__
+/python/constraint_grammar_wrap.cpp
+/python/constraint_grammar.py
+/python/setup.py
+/python/build*
+*.egg-info/
+*.egg
+/python/CMakeCache.txt
+/python/CMakeFiles
+/python/cmake_install.cmake
+/python/CTestTestfile.cmake
+/python/install_manifest.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: cpp
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ addons:
       - cmake
       - libboost-dev
       - libicu-dev
+      - swig
 
 before_script:
-  - cmake .
+  - cmake -DENABLE_PYTHON_BINDINGS:BOOL=ON .
 
 script:
   - $CXX --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
-cmake_minimum_required(VERSION 2.8.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
 project(cg3 CXX C)
 
 # Release or Debug
@@ -29,6 +29,8 @@ endif()
 
 option(BUILD_SHARED_LIBS "Set to OFF to use static library" ON)
 option(USE_TCMALLOC "Set to OFF to disable linking against TCMalloc" ON)
+option(ENABLE_PYTHON_BINDINGS "Set to ON to build the python wrapper" OFF)
+
 if(APPLE)
 	message(STATUS "Disabling TCMalloc for OS X")
 	set(USE_TCMALLOC OFF)
@@ -125,6 +127,10 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
 enable_testing()
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+if(ENABLE_PYTHON_BINDINGS)
+	add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/python)
+endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/cg3-autobin.pl.in ${CMAKE_CURRENT_BINARY_DIR}/scripts/cg3-autobin.pl @ONLY)
 install(PROGRAMS

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(Python_ADDITIONAL_VERSIONS 3.5)
+find_package(PythonInterp REQUIRED)
+
+set(PYTHON_FILE "constraint_grammar.py")
+set(CPP_WRAP_FILE "constraint_grammar_wrap.cpp")
+
+configure_file( setup.py.in setup.py )
+
+add_custom_command(OUTPUT ${CPP_WRAP_FILE} ${PYTHON_FILE}
+    COMMAND ${PYTHON_EXECUTABLE} setup.py build
+    COMMENT "Building ${PYTHON_FILE}"
+)
+
+add_custom_target(wrapper ALL
+    DEPENDS ${CPP_WRAP_FILE} ${PYTHON_FILE}
+    VERBATIM
+)
+
+set (INSTALL_WRAPPER "${PYTHON_EXECUTABLE} setup.py install --prefix=${CMAKE_INSTALL_PREFIX}")
+install(CODE "execute_process(COMMAND ${INSTALL_WRAPPER} WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})")

--- a/python/constraint_grammar.i
+++ b/python/constraint_grammar.i
@@ -87,13 +87,13 @@ void CGProc::cg_proc(char argc, char **argv, char *input_path, char *output_path
 
 	int c = 0;
 	optind = 1;
-	while(true){
+	while (true) {
 		c = getopt(argc, argv, "s:f:tn1wz");
 		if (c == -1) {
 			break;
 		}
 
-		switch(c){
+		switch (c) {
 			case 'f':
 				stream_format = atoi(optarg);
 				break;
@@ -116,6 +116,7 @@ void CGProc::cg_proc(char argc, char **argv, char *input_path, char *output_path
 			case 'w':
 				wordform_case = true;
 				break;
+
 			case 'z':
 				null_flush = true;
 				break;

--- a/python/constraint_grammar.i
+++ b/python/constraint_grammar.i
@@ -1,0 +1,147 @@
+%module constraint_grammar
+
+%include <std_map.i>
+%include <std_string.i>
+%include <std_vector.i>
+%include <Grammar.hpp>
+
+%typemap(in) char ** {
+  if (PyList_Check($input)) {
+    int size = PyList_Size($input);
+    int i = 0;
+    $1 = (char **) malloc((size+1)*sizeof(char *));
+    for (i = 0; i < size; i++) {
+      PyObject *py_obj = PyList_GetItem($input, i);
+      if (PyUnicode_Check(py_obj)) {
+        $1[i] = strdup(PyUnicode_AsUTF8(py_obj));
+      }
+      else {
+        PyErr_SetString(PyExc_TypeError, "list must contain strings");
+        free($1);
+        return NULL;
+      }
+    }
+    $1[i] = 0;
+  } else {
+    PyErr_SetString(PyExc_TypeError, "not a list");
+    return NULL;
+  }
+}
+
+%inline%{
+#define SWIG_FILE_WITH_INIT
+#include "stdafx.hpp"
+#include "Grammar.hpp"
+#include "TextualParser.hpp"
+#include "BinaryGrammar.hpp"
+#include "ApertiumApplicator.hpp"
+#include "MatxinApplicator.hpp"
+#include "GrammarApplicator.hpp"
+
+#include <getopt.h>
+
+class CGProc: public CG3::Grammar
+{
+private:
+	CG3::Grammar grammar;
+
+public:
+	CGProc(char *dictionary_path);
+	void cg_proc(char argc, char **argv, char *input_path, char *output_path);
+};
+
+CGProc::CGProc(char *dictionary_path)
+{
+	std::unique_ptr<CG3::IGrammarParser> parser;
+	FILE* dictionary = fopen(dictionary_path, "rb");
+	fread(&CG3::cbuffers[0][0], 1, 4, dictionary);
+	fclose(dictionary);
+	if (CG3::cbuffers[0][0] == 'C' && CG3::cbuffers[0][1] == 'G' && CG3::cbuffers[0][2] == '3' && CG3::cbuffers[0][3] == 'B') {
+		parser.reset(new CG3::BinaryGrammar(grammar, std::cerr));
+	}
+	else {
+		parser.reset(new CG3::TextualParser(grammar, std::cerr));
+	}
+	parser->parse_grammar(dictionary_path);
+}
+
+void CGProc::cg_proc(char argc, char **argv, char *input_path, char *output_path)
+{
+	bool trace = false;
+	bool wordform_case = false;
+	bool print_word_forms = true;
+	bool only_first = false;
+	int cmd = 0;
+	int sections = 0;
+	int stream_format = 1;
+	bool null_flush = false;
+	std::string single_rule;
+
+	UErrorCode status = U_ZERO_ERROR;
+	std::ifstream input;
+	input.open(input_path, std::ios::binary);
+	std::istream& ux_stdin = input;
+	std::ofstream output;
+	output.open(output_path, std::ios::binary);
+	std::ostream& ux_stdout = output;
+
+	int c = 0;
+	optind = 1;
+	while(true){
+		c = getopt(argc, argv, "s:f:tn1wz");
+		if (c == -1) {
+			break;
+		}
+
+		switch(c){
+			case 'f':
+				stream_format = atoi(optarg);
+				break;
+
+			case 't':
+				trace = true;
+				break;
+			case 's':
+				sections = atoi(optarg);
+				break;
+
+			case 'n':
+				print_word_forms = false;
+				break;
+
+			case '1':
+				only_first = true;
+				break;
+
+			case 'w':
+				wordform_case = true;
+				break;
+			case 'z':
+				null_flush = true;
+				break;
+		}
+	}
+	grammar.reindex();
+	std::unique_ptr<CG3::GrammarApplicator> applicator;
+
+	CG3::ApertiumApplicator* apertiumApplicator = new CG3::ApertiumApplicator(std::cerr);
+	apertiumApplicator->setNullFlush(null_flush);
+	apertiumApplicator->wordform_case = wordform_case;
+	apertiumApplicator->print_word_forms = print_word_forms;
+	apertiumApplicator->print_only_first = only_first;
+	applicator.reset(apertiumApplicator);
+
+	applicator->setGrammar(&grammar);
+	for (int32_t i = 1; i <= sections; i++) {
+		applicator->sections.push_back(i);
+	}
+
+	applicator->trace = trace;
+	applicator->unicode_tags = true;
+	applicator->unique_tags = false;
+
+	applicator->runGrammarOnText(ux_stdin, ux_stdout);
+	u_cleanup();
+}
+
+%}

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+"""
+Setup for SWIG Python bindings for constraint_grammar
+"""
+from os import path
+from distutils.core import Extension, setup
+from distutils.command.build import build
+
+
+class CustomBuild(build):
+    sub_commands = [
+        ('build_ext', build.has_ext_modules),
+        ('build_py', build.has_pure_modules),
+        ('build_clib', build.has_c_libraries),
+        ('build_scripts', build.has_scripts),
+    ]
+
+
+def get_sources():
+    sources = ['constraint_grammar.i', '${CMAKE_SOURCE_DIR}/include/posix/popen_plus.cpp']
+    cc_sources = [
+        'ApertiumApplicator.cpp', 'BinaryGrammar.cpp', 'BinaryGrammar_read.cpp', 'BinaryGrammar_read_10043.cpp',
+        'BinaryGrammar_write.cpp', 'Cohort.cpp', 'CohortIterator.cpp', 'ContextualTest.cpp', 'Grammar.cpp',
+        'GrammarApplicator.cpp', 'GrammarApplicator_matchSet.cpp', 'GrammarApplicator_reflow.cpp',
+        'GrammarApplicator_runContextualTest.cpp', 'GrammarApplicator_runGrammar.cpp',
+        'GrammarApplicator_runRules.cpp', 'GrammarWriter.cpp', 'MatxinApplicator.cpp',
+        'Reading.cpp', 'Rule.cpp', 'Set.cpp', 'SingleWindow.cpp', 'Strings.cpp', 'Tag.cpp',
+        'TextualParser.cpp', 'Window.cpp', 'uextras.cpp',
+    ]
+    rel_path = '${CMAKE_SOURCE_DIR}/src/'
+    sources.extend(path.join(rel_path, f) for f in cc_sources)
+    return sources
+
+constraint_grammar_module = Extension(
+    name='_constraint_grammar',
+    sources=get_sources(),
+    swig_opts = ['-c++', '-I/usr/include', '-I${CMAKE_SOURCE_DIR}', '-I${CMAKE_SOURCE_DIR}/src', '-I${CMAKE_SOURCE_DIR}/include', '-Wall'],
+    include_dirs=['${CMAKE_SOURCE_DIR}', '${CMAKE_SOURCE_DIR}/src', '${CMAKE_SOURCE_DIR}/include', '${CMAKE_SOURCE_DIR}/include/posix'],
+    extra_compile_args='${CMAKE_CXX_FLAGS}'.split(),
+    extra_link_args=['-lxml2', '-licuuc', '-licuio', '-licui18n'],
+)
+
+setup(
+    name='constraint_grammar',
+    version='${VERSION}',
+    description='SWIG interface to constraint_grammar',
+    long_description='SWIG interface to constraint_grammar for use in apertium-python',
+    # TODO: author, author_email, maintainer, url
+    license='GPL-3.0+',
+    cmdclass={'build': CustomBuild},
+    ext_modules=[constraint_grammar_module],
+    py_modules=['constraint_grammar'],
+)

--- a/src/Grammar.hpp
+++ b/src/Grammar.hpp
@@ -53,103 +53,103 @@ public:
 	uint32_t verbosity_level;
 	mutable double total_time;
 
-	std::vector<Tag*> single_tags_list;
-	Taguint32HashMap single_tags;
+	std::vector<CG3::Tag*> single_tags_list;
+	CG3::Taguint32HashMap single_tags;
 
-	std::vector<Set*> sets_list;
-	SetSet sets_all;
-	uint32FlatHashMap sets_by_name;
-	typedef std::unordered_map<UString, uint32_t, hash_ustring> set_name_seeds_t;
+	std::vector<CG3::Set*> sets_list;
+	CG3::SetSet sets_all;
+	CG3::uint32FlatHashMap sets_by_name;
+	typedef std::unordered_map<CG3::UString, uint32_t, hash_ustring> set_name_seeds_t;
 	set_name_seeds_t set_name_seeds;
-	Setuint32HashMap sets_by_contents;
-	uint32FlatHashMap set_alias;
-	SetSet maybe_used_sets;
+	CG3::Setuint32HashMap sets_by_contents;
+	CG3::uint32FlatHashMap set_alias;
+	CG3::SetSet maybe_used_sets;
 
-	typedef std::vector<UString> static_sets_t;
+	typedef std::vector<CG3::UString> static_sets_t;
 	static_sets_t static_sets;
 
 	typedef std::set<URegularExpression*> regex_tags_t;
 	regex_tags_t regex_tags;
-	typedef TagSortedVector icase_tags_t;
+	typedef CG3::TagSortedVector icase_tags_t;
 	icase_tags_t icase_tags;
 
-	typedef std::unordered_map<uint32_t, ContextualTest*> contexts_t;
+	typedef std::unordered_map<uint32_t, CG3::ContextualTest*> contexts_t;
 	contexts_t templates;
 	contexts_t contexts;
 
-	typedef std::unordered_map<uint32_t, uint32IntervalVector> rules_by_set_t;
+	typedef std::unordered_map<uint32_t, CG3::uint32IntervalVector> rules_by_set_t;
 	rules_by_set_t rules_by_set;
-	typedef std::unordered_map<uint32_t, uint32IntervalVector> rules_by_tag_t;
+	typedef std::unordered_map<uint32_t, CG3::uint32IntervalVector> rules_by_tag_t;
 	rules_by_tag_t rules_by_tag;
 	typedef std::unordered_map<uint32_t, boost::dynamic_bitset<>> sets_by_tag_t;
 	sets_by_tag_t sets_by_tag;
 
-	uint32IntervalVector* rules_any;
+	CG3::uint32IntervalVector* rules_any;
 	boost::dynamic_bitset<>* sets_any;
 
-	Set* delimiters;
-	Set* soft_delimiters;
+	CG3::Set* delimiters;
+	CG3::Set* soft_delimiters;
 	uint32_t tag_any;
-	uint32Vector preferred_targets;
-	uint32SortedVector reopen_mappings;
+	CG3::uint32Vector preferred_targets;
+	CG3::uint32SortedVector reopen_mappings;
 	typedef bc::flat_map<uint32_t, uint32_t> parentheses_t;
 	parentheses_t parentheses;
 	parentheses_t parentheses_reverse;
 
-	uint32Vector sections;
-	uint32FlatHashMap anchors;
+	CG3::uint32Vector sections;
+	CG3::uint32FlatHashMap anchors;
 
-	RuleVector rule_by_number;
-	RuleVector before_sections;
-	RuleVector rules;
-	RuleVector after_sections;
-	RuleVector null_section;
-	RuleVector wf_rules;
+	CG3::RuleVector rule_by_number;
+	CG3::RuleVector before_sections;
+	CG3::RuleVector rules;
+	CG3::RuleVector after_sections;
+	CG3::RuleVector null_section;
+	CG3::RuleVector wf_rules;
 
 	Grammar();
 	~Grammar();
 
-	void addSet(Set*& to);
-	Set* getSet(uint32_t which) const;
-	Set* allocateSet();
-	void destroySet(Set* set);
-	void addSetToList(Set* s);
+	void addSet(CG3::Set*& to);
+	CG3::Set* getSet(uint32_t which) const;
+	CG3::Set* allocateSet();
+	void destroySet(CG3::Set* set);
+	void addSetToList(CG3::Set* s);
 	void allocateDummySet();
 	uint32_t removeNumericTags(uint32_t s);
-	void getTags(const Set& set, std::set<TagVector>& rv);
+	void getTags(const CG3::Set& set, std::set<CG3::TagVector>& rv);
 
 	void addAnchor(const UChar* to, uint32_t at, bool primary = false);
-	void addAnchor(const UString& to, uint32_t at, bool primary = false);
+	void addAnchor(const CG3::UString& to, uint32_t at, bool primary = false);
 
-	Tag* allocateTag();
-	Tag* allocateTag(const UChar* tag);
-	Tag* allocateTag(const UString& tag);
-	Tag* addTag(Tag* tag);
-	void destroyTag(Tag* tag);
-	void addTagToSet(Tag* rtag, Set* set);
+	CG3::Tag* allocateTag();
+	CG3::Tag* allocateTag(const UChar* tag);
+	CG3::Tag* allocateTag(const CG3::UString& tag);
+	CG3::Tag* addTag(CG3::Tag* tag);
+	void destroyTag(CG3::Tag* tag);
+	void addTagToSet(CG3::Tag* rtag, CG3::Set* set);
 
-	Rule* allocateRule();
-	void addRule(Rule* rule);
-	void destroyRule(Rule* rule);
+	CG3::Rule* allocateRule();
+	void addRule(CG3::Rule* rule);
+	void destroyRule(CG3::Rule* rule);
 
-	ContextualTest* allocateContextualTest();
-	ContextualTest* addContextualTest(ContextualTest* t);
-	void addTemplate(ContextualTest* test, const UChar* name);
+	CG3::ContextualTest* allocateContextualTest();
+	CG3::ContextualTest* addContextualTest(CG3::ContextualTest* t);
+	void addTemplate(CG3::ContextualTest* test, const UChar* name);
 
 	void resetStatistics();
 	void reindex(bool unused_sets = false, bool used_tags = false);
 	void renameAllRules();
 
-	void indexSetToRule(uint32_t, Set*);
+	void indexSetToRule(uint32_t, CG3::Set*);
 	void indexTagToRule(uint32_t, uint32_t);
-	void indexSets(uint32_t, Set*);
+	void indexSets(uint32_t, CG3::Set*);
 	void indexTagToSet(uint32_t, uint32_t);
-	void setAdjustSets(Set*);
-	void contextAdjustTarget(ContextualTest*);
+	void setAdjustSets(CG3::Set*);
+	void contextAdjustTarget(CG3::ContextualTest*);
 };
 
 template<typename Stream>
-inline void _trie_unserialize(trie_t& trie, Stream& input, Grammar& grammar, uint32_t num_tags) {
+inline void _trie_unserialize(CG3::trie_t& trie, Stream& input, Grammar& grammar, uint32_t num_tags) {
 	for (uint32_t i = 0; i < num_tags; ++i) {
 		uint32_t u32tmp = 0;
 		fread_throw(&u32tmp, sizeof(uint32_t), 1, input);
@@ -164,18 +164,18 @@ inline void _trie_unserialize(trie_t& trie, Stream& input, Grammar& grammar, uin
 		u32tmp = ntoh32(u32tmp);
 		if (u32tmp) {
 			if (!node.trie) {
-				node.trie = new trie_t;
+				node.trie = new CG3::trie_t;
 			}
 			trie_unserialize(*node.trie, input, grammar, u32tmp);
 		}
 	}
 }
 
-inline void trie_unserialize(trie_t& trie, FILE* input, Grammar& grammar, uint32_t num_tags) {
+inline void trie_unserialize(CG3::trie_t& trie, FILE* input, Grammar& grammar, uint32_t num_tags) {
 	return _trie_unserialize(trie, input, grammar, num_tags);
 }
 
-inline void trie_unserialize(trie_t& trie, std::istream& input, Grammar& grammar, uint32_t num_tags) {
+inline void trie_unserialize(CG3::trie_t& trie, std::istream& input, Grammar& grammar, uint32_t num_tags) {
 	return _trie_unserialize(trie, input, grammar, num_tags);
 }
 }


### PR DESCRIPTION
guarded by `ENABLE_PYTHON_BINDINGS`

- updated `cmake` minimum version to `3.0.2` for finding python interpreter
- modified `Grammar.hpp` for including in swig wrapper
- updated travis distro to `xenial`

Usage:
```
cg = constraint_grammar.CGProc(dictionary_path)
command = ['cg-proc', '-w']
cg.cg_proc(len(command), command, input_file.name, output_file.name)
```