### PR TITLE
Handle closing wblanks

### DIFF
--- a/src/ApertiumApplicator.cpp
+++ b/src/ApertiumApplicator.cpp
@@ -339,18 +339,24 @@ void ApertiumApplicator::runGrammarOnText(std::istream& input, std::ostream& out
 			}
 			in_cohort = false;
 
+			bool is_closing_wblank = false;
 			if (!blank.empty()) {
 				wblank.clear();
 				auto b = blank.find(wb_start);
 				auto e = blank.find(wb_end, b);
 				if (b != UString::npos && e != UString::npos) {
-					// Word-bound blanks are always immediately prior to the token they belong to
+					// Word-bound blanks are always immediately prior to the token they belong to,
+					// except closing word blanks which are immediately after
 					wblank = blank.substr(b);
 					blank.erase(b, UString::npos);
+					if (e == b+3 && wblank[2] == '/') {
+						is_closing_wblank = true;
+					}
 				}
 			}
-			if (!wblank.empty() && (wblank[wblank.size() - 1] != ']' || wblank[wblank.size() - 2] != ']')) {
-				u_fprintf(ux_stderr, "Error: Word-bound blank was not immediately prior to token on line %u.\n", numLines);
+			if (!is_closing_wblank && // there are characters in the blank after the ]]:
+			    !wblank.empty() && (wblank[wblank.size() - 1] != ']' || wblank[wblank.size() - 2] != ']')) {
+				u_fprintf(ux_stderr, "Error: Word-bound blank was not immediately prior to token on line %u\n", numLines);
 				CG3Quit(1);
 			}
 

--- a/test/Apertium/T_Generate/expected.txt
+++ b/test/Apertium/T_Generate/expected.txt
@@ -1,0 +1,1 @@
+[[t:i:HatKkQ]]steikje[[/]]![]

--- a/test/Apertium/T_Generate/grammar.cg3
+++ b/test/Apertium/T_Generate/grammar.cg3
@@ -1,0 +1,8 @@
+DELIMITERS = "<.>" "<!>" ;
+
+LIST kj_k = v:kj_k ;
+
+SECTION
+
+SELECT kj_k IF (0 (VAR:kj_k)) ;
+REMOVE kj_k ;

--- a/test/Apertium/T_Generate/input.txt
+++ b/test/Apertium/T_Generate/input.txt
@@ -1,0 +1,2 @@
+[[t:i:HatKkQ]]^steikje<adv>/steik<v:kj_k>e/steikje$[[/]] ^!<sent>/!$[]
+

--- a/test/Apertium/T_Generate/run.pl
+++ b/test/Apertium/T_Generate/run.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Cwd qw(realpath);
+
+my ($bindir, $sep) = $0 =~ /^(.*)(\\|\/).*/;
+$bindir = realpath $bindir;
+chdir $bindir or die("Error: Could not change directory to $bindir !");
+
+my $bpath = $ARGV[0];
+my $binary = $bpath."cg-proc";
+my $compiler = $bpath."cg-comp";
+
+`"$compiler" grammar.cg3 grammar.bin  >stdout.txt 2>stderr.txt`;
+`"$binary" -g -1 -n grammar.bin  input.txt output.txt >>stdout.txt 2>>stderr.txt`;
+`diff -B expected.txt output.txt >diff.txt`;
+
+if (-s "diff.txt") {
+	print STDERR "Fail.\n";
+} else {
+	print STDERR "Success.\n";
+}


### PR DESCRIPTION
cg-proc exits with nonzero if there's anything at all between a wblank and the following lexical unit (seems a bit harsh, but perhaps that's a strong assumption about this elsewhere?). But IIUC the `[[/]]` blanks should be *after* lexical units; this PR fixes that.